### PR TITLE
[#12] Expire tokens instead of deleting them

### DIFF
--- a/test/authority_ecto/templates/recovery_test.exs
+++ b/test/authority_ecto/templates/recovery_test.exs
@@ -57,7 +57,7 @@ defmodule Authority.Ecto.Template.RecoveryTest do
       assert {:ok, %User{}} = Accounts.authenticate({"valid@email.com", "new_password"})
 
       # Token cannot be used twice
-      assert {:error, :invalid_token} =
+      assert {:error, :expired_token} =
                Accounts.update_user(token, %{
                  password: "third_password",
                  password_confirmation: "third_password"


### PR DESCRIPTION
Also, as mentioned in #12, expire only the ones that belong to the
current user.

I think it's better to expire old tokens rather than
delete them, in order to preserve history for security/breach audits,
etc.

Fixes #12.