### PR TITLE
Require confirmation only if password changed

### DIFF
--- a/lib/authority/ecto/changeset.ex
+++ b/lib/authority/ecto/changeset.ex
@@ -62,7 +62,7 @@ defmodule Authority.Ecto.Changeset do
   def validate_secure_password(changeset, field) do
     changeset
     |> validate_length(field, min: 8)
-    |> validate_confirmation(field, required: true)
+    |> validate_confirmation(field, required: get_change(changeset, field) != nil)
     |> validate_nonrepetitive(field)
     |> validate_nonconsecutive(field)
     |> validate_exclusion(field, Password.blacklist(), message: "is too common")

--- a/test/authority/ecto/changeset_test.exs
+++ b/test/authority/ecto/changeset_test.exs
@@ -19,6 +19,74 @@ defmodule Authority.Ecto.ChangesetTest do
     password_confirmation: "testing123"
   }
 
+  describe ".put_encrypted_password/3" do
+    test "deletes virtual attributes" do
+      changeset =
+        %User{}
+        |> change(@valid_attrs)
+        |> Changeset.put_encrypted_password(:password, :encrypted_password)
+
+      refute get_change(changeset, :password)
+      refute get_change(changeset, :password_confirmation)
+    end
+  end
+
+  describe ".put_encrypted_password/4" do
+    test "supports :bcrypt algorithm" do
+      test_encrypted_password(:bcrypt, Comeonin.Bcrypt)
+    end
+
+    test "supports :argon2 algorithm" do
+      test_encrypted_password(:argon2, Comeonin.Argon2)
+    end
+
+    test "supports :pbkdf2 algorithm" do
+      test_encrypted_password(:pbkdf2, Comeonin.Pbkdf2)
+    end
+  end
+
+  describe ".put_token_expiration/3" do
+    test "sets the expires_at field" do
+      changeset =
+        %Token{}
+        |> change(%{purpose: "72_hours"})
+        |> Changeset.put_token_expiration(:expires_at, :purpose, @expirations)
+
+      actual =
+        changeset
+        |> get_change(:expires_at)
+        |> DateTime.to_unix()
+
+      expected =
+        DateTime.utc_now()
+        |> DateTime.to_unix()
+        |> Kernel.+(259_200)
+
+      assert_in_delta actual, expected, 5
+    end
+
+    test "changes nothing when no timespec is configured" do
+      changeset =
+        %Token{}
+        |> change(%{purpose: "baloney"})
+        |> Changeset.put_token_expiration(:expires_at, :purpose, @expirations)
+
+      refute get_change(changeset, :expires_at)
+    end
+  end
+
+  describe ".validate_secure_password/2" do
+    @tag :regression
+    test "does not require password_confirmation if password not changed" do
+      changeset =
+        %User{}
+        |> change(%{email: "test@email.com"})
+        |> Changeset.validate_secure_password(:password)
+
+      assert changeset.errors == []
+    end
+  end
+
   defp test_encrypted_password(name, mod) do
     changeset =
       %User{}
@@ -27,55 +95,5 @@ defmodule Authority.Ecto.ChangesetTest do
 
     assert hash = get_change(changeset, :encrypted_password)
     assert mod.checkpw(@valid_attrs.password, hash)
-  end
-
-  test "put_encrypted_password/3 deletes virtual attributes" do
-    changeset =
-      %User{}
-      |> change(@valid_attrs)
-      |> Changeset.put_encrypted_password(:password, :encrypted_password)
-
-    refute get_change(changeset, :password)
-    refute get_change(changeset, :password_confirmation)
-  end
-
-  test "put_encrypted_password/4 (bcrypt)" do
-    test_encrypted_password(:bcrypt, Comeonin.Bcrypt)
-  end
-
-  test "put_encrypted_password/4 (argon2)" do
-    test_encrypted_password(:argon2, Comeonin.Argon2)
-  end
-
-  test "put_encrypted_password/4 (pbkdf2)" do
-    test_encrypted_password(:pbkdf2, Comeonin.Pbkdf2)
-  end
-
-  test "put_token_expiration/3 sets the expires_at" do
-    changeset =
-      %Token{}
-      |> change(%{purpose: "72_hours"})
-      |> Changeset.put_token_expiration(:expires_at, :purpose, @expirations)
-
-    actual =
-      changeset
-      |> get_change(:expires_at)
-      |> DateTime.to_unix()
-
-    expected =
-      DateTime.utc_now()
-      |> DateTime.to_unix()
-      |> Kernel.+(259_200)
-
-    assert_in_delta actual, expected, 5
-  end
-
-  test "put_token_expiration/3 when no timespec is configured" do
-    changeset =
-      %Token{}
-      |> change(%{purpose: "baloney"})
-      |> Changeset.put_token_expiration(:expires_at, :purpose, @expirations)
-
-    refute get_change(changeset, :expires_at)
   end
 end


### PR DESCRIPTION
Currently, `validate_secure_password/1` will raise an error if you try
to change any field on your `User` without specifying
`password_confirmation`.

This commit makes it so that the `confirmation` field will only be required if you try to change the designated password field.