### PR TITLE
Fix typespecs on `change_user/0` - `change_user/2`

### DIFF
--- a/lib/authority/ecto/template.ex
+++ b/lib/authority/ecto/template.ex
@@ -174,6 +174,8 @@ defmodule Authority.Ecto.Template do
         import Ecto.Changeset
         import Authority.Ecto.Changeset
 
+        @type t :: %__MODULE__{}
+
         schema "users" do
           field :email, :string
           field :encrypted_password, :string
@@ -201,6 +203,8 @@ defmodule Authority.Ecto.Template do
 
         import Ecto.Changeset
         import Authority.Ecto.Changeset
+
+        @type t :: %__MODULE__{}
 
         defmodule Purpose do
           use Exnumerator, values: [:any, :recovery]
@@ -235,6 +239,8 @@ defmodule Authority.Ecto.Template do
         use Ecto.Schema
 
         import Ecto.Changeset
+
+        @type t :: %__MODULE__{}
 
         defmodule Reason do
           use Exnumerator, values: [:too_many_attempts]

--- a/lib/authority/ecto/templates/registration.ex
+++ b/lib/authority/ecto/templates/registration.ex
@@ -202,16 +202,12 @@ defmodule Authority.Ecto.Template.Registration do
             # => {:error, :invalid_token}
         """
         @impl Authority.Registration
-        @spec change_user :: {:ok, Ecto.Changeset.t()} | auth_failure
+        @spec change_user :: {:ok, Ecto.Changeset.t()}
         @spec change_user(@user_schema.t() | @token_schema.t()) ::
                 {:ok, Ecto.Changeset.t()} | auth_failure
         @spec change_user(@user_schema.t() | @token_schema.t(), map) ::
                 {:ok, Ecto.Changeset.t()} | auth_failure
-        def change_user(user_or_token \\ nil, params \\ %{})
-
-        def change_user(nil, params) do
-          {:ok, @user_schema.changeset(%@user_schema{}, params)}
-        end
+        def change_user(user_or_token \\ %@user_schema{}, params \\ %{})
 
         def change_user(%@user_schema{} = user, params) do
           {:ok, @user_schema.changeset(user, params)}


### PR DESCRIPTION
Per #20. I experimented with using `%@user_schema{}` for the typespecs,
but got weird errors, so I decided to keep the `.t` references for now.

I think these tweaks will fix the problem Dialyzer is reporting in #20.

I added `@type t :: %__MODULE__{}` lines to all the example schemas in
the documentation as well.