### PR TITLE
Lock/unlock around the tokenize event

### DIFF
--- a/lib/authority/ecto/template.ex
+++ b/lib/authority/ecto/template.ex
@@ -367,5 +367,9 @@ defmodule Authority.Ecto.Template do
     Module.defines?(module, {:tokenize, 2})
   end
 
+  def implements?(module, Authority.Locking) do
+    Module.defines?(module, {:lock, 2})
+  end
+
   def implements?(_module, _behaviour), do: false
 end

--- a/lib/authority/ecto/templates/locking.ex
+++ b/lib/authority/ecto/templates/locking.ex
@@ -87,21 +87,6 @@ defmodule Authority.Ecto.Template.Locking do
 
       @doc false
       @impl Authority.Authentication
-      def before_validate(user, _purpose) do
-        case get_lock(user) do
-          {:ok, lock} -> {:error, lock}
-          _other -> :ok
-        end
-      end
-
-      @doc false
-      @impl Authority.Authentication
-      def after_validate(user, _purpose) do
-        unlock(user)
-      end
-
-      @doc false
-      @impl Authority.Authentication
       def failed(user, _error) do
         create_attempt(user)
 

--- a/test/authority/ecto/templates/kitchen_sink_test.exs
+++ b/test/authority/ecto/templates/kitchen_sink_test.exs
@@ -28,10 +28,10 @@ defmodule Authority.Ecto.KitchenSinkTest do
   describe ".tokenize/2" do
     test "locks account after too many failed attempts" do
       for _ <- 1..5 do
-        Accounts.tokenize({"valid@email.com", "invalid"})
+        Accounts.authenticate({"valid@email.com", "invalid"})
       end
 
-      assert {:error, %Lock{}} = Accounts.tokenize({"valid@email.com", "valid"})
+      assert {:error, %Lock{}} = Accounts.tokenize({"valid@email.com", "password"})
     end
   end
 end


### PR DESCRIPTION
This definitely works, but a more elegant solution could be to offer `before_tokenize` and `after_tokenize` callbacks in Authority.

Fixes #24 

Note: This is a breaking change.