### PR TITLE
Don't attempt to HMAC a nil value

### DIFF
--- a/lib/authority/ecto/hmac.ex
+++ b/lib/authority/ecto/hmac.ex
@@ -97,9 +97,11 @@ defmodule Authority.Ecto.HMAC do
       def type, do: :string
 
       @doc false
+      def cast(nil), do: {:ok, nil}
       def cast(value), do: {:ok, to_string(value)}
 
       @doc false
+      def dump(nil), do: {:ok, nil}
       def dump(value), do: {:ok, HMAC.hash(value, HMAC.secret!(@config))}
 
       @doc false

--- a/test/authority/ecto/hmac_test.exs
+++ b/test/authority/ecto/hmac_test.exs
@@ -26,6 +26,12 @@ defmodule Authority.Ecto.HMACTest do
       assert Type.dump("value") ==
                {:ok, "4485C853B0D13593389A00B317DA829322F3A3734D63C339E97EAD273441CA45"}
     end
+
+    test "respects nil" do
+      assert Type.cast(nil) == {:ok, nil}
+      assert Type.dump(nil) == {:ok, nil}
+      assert Type.load(nil) == {:ok, nil}
+    end
   end
 
   describe ".hash/2" do


### PR DESCRIPTION
This PR is an alternative to #23, which allows the HMAC type to respect nils.