### PR TITLE
Restore the locking behavior

### DIFF
--- a/lib/authority/ecto/templates/locking.ex
+++ b/lib/authority/ecto/templates/locking.ex
@@ -87,6 +87,15 @@ defmodule Authority.Ecto.Template.Locking do
 
       @doc false
       @impl Authority.Authentication
+      def before_validate(user, _purpose) do
+        case get_lock(user) do
+          {:ok, lock} -> {:error, lock}
+          _other -> :ok
+        end
+      end
+
+      @doc false
+      @impl Authority.Authentication
       def failed(user, _error) do
         create_attempt(user)
 

--- a/lib/authority/ecto/templates/tokenization.ex
+++ b/lib/authority/ecto/templates/tokenization.ex
@@ -64,7 +64,7 @@ defmodule Authority.Ecto.Template.Tokenization do
 
       def validate(credential, user, purpose), do: super(credential, user, purpose)
 
-      # TOKENIZATION 
+      # TOKENIZATION
       # —————————————————————————————————————————————————————————————————————————
 
       use Authority.Tokenization
@@ -147,13 +147,9 @@ defmodule Authority.Ecto.Template.Tokenization do
             %@token_schema{@token_user_assoc => user}
             |> @token_schema.changeset(%{@token_purpose_field => purpose})
 
-          case get_lock(user) do
-            {:ok, lock} ->
-              {:error, lock}
-
-            _other ->
-              unlock(user)
-              @repo.insert(changeset)
+          with {:ok, token} <- @repo.insert(changeset) do
+            :ok = unlock(user)
+            {:ok, token}
           end
         end
       end

--- a/test/authority/ecto/templates/kitchen_sink_test.exs
+++ b/test/authority/ecto/templates/kitchen_sink_test.exs
@@ -31,7 +31,7 @@ defmodule Authority.Ecto.KitchenSinkTest do
         Accounts.authenticate({"valid@email.com", "invalid"})
       end
 
-      assert {:error, %Lock{}} = Accounts.tokenize({"valid@email.com", "password"})
+      assert {:error, %Lock{}} = Accounts.authenticate({"valid@email.com", "password"})
     end
   end
 end

--- a/test/authority/ecto/templates/locking_test.exs
+++ b/test/authority/ecto/templates/locking_test.exs
@@ -32,14 +32,14 @@ defmodule Authority.Ecto.Template.LockingTest do
       end
 
       assert {:error, %Lock{reason: :too_many_attempts}} =
-               Accounts.tokenize({"valid@email.com", "password"})
+               Accounts.authenticate({"valid@email.com", "password"})
     end
   end
 
   describe ".lock/2" do
     test "locks a user account", %{user: user} do
       assert {:ok, %Lock{}} = Accounts.lock(user, :too_many_attempts)
-      assert {:error, %Lock{}} = Accounts.tokenize({"valid@email.com", "password"})
+      assert {:error, %Lock{}} = Accounts.authenticate({"valid@email.com", "password"})
     end
   end
 


### PR DESCRIPTION
Restore the locking behavior to how it worked before #25, except that unlocking happens when it needs to.

We still want to check for locks in `before_validate/2`, because we need an unsuccessful login attempt to fail with `{:error, %Lock{}}`. This way, we can tell the user that their account is locked.

Locks get cleared as a side-effect of successful tokenization.

The problem with the current behavior in master is that when an account is locked, it'll still fail with `{:error, :invalid_password}`.